### PR TITLE
Use alpine instead slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10.0-slim
+FROM node:6.10.0-alpine
 MAINTAINER SourceLevel <support@sourcelevel.io>
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Slim image does not contain expected `apk` command.

Specify `alpine` image solves the problem